### PR TITLE
Fix pm2 setup & usage to support capistrano style

### DIFF
--- a/pm2.json
+++ b/pm2.json
@@ -1,0 +1,9 @@
+{
+  "apps": [{
+    "name": "freakin-hapi-app",
+    "script": "server.js",
+    "cwd": "/home/vagrant/freakin-hapi-app/current",
+    "instances": "max",
+    "exec_mode": "cluster"
+  }]
+}


### PR DESCRIPTION
The only way pm2 can support capistrano like deployments is if a config file is used rather than calling the app directly. http://pm2.keymetrics.io/docs/tutorials/capistrano-like-deployments

This is because of the use of a symlinked 'current' directory which is pointed to a seperate release folder. If you call your server.js script directly using pm2 within the project root, it won't pick up that 'current' has been repointed on subsequent deployments.

The way to resolve this is to call pm2 passing in a config file instead, and in that specify the start script and the current working directory for pm2.

We therefore use shipit to copy across our pm2 config to the instance(s) ready to be refereneced in the start task, and when we start pm2, we refer to the config file rather than starting the app directly.