### PR TITLE
Add npm verification & notes on npm install issues

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,22 +69,9 @@ Vagrant.configure("2") do |config|
   SHELL
 
   config.vm.provision "shell", name: "npm", inline: <<-SHELL
-    # Kept getting `Unhandled rejection Error: EPERM: operation not permitted, link `
-    # errors when it came to running `npm install` for the deployed app.
-    # Upgrading npm seemed to resolve the problem, but when just trying
-    # `npm install -g npm` we would get a `cb() never called!` error. So using
-    # some info from this post https://github.com/npm/npm/issues/16551 we do
-    # the following to get npm upgraded and the app deploying successfully on
-    # the vagrant box.
-    # N.B. these also require sudo but by default this script will run as
-    # priveleged hence we don't specify it
-    npm cache clean --force
-    rm -rf ~/.npm
+    # Verify the contents of the cache folder to avoid issues when upgrading npm
+    npm cache verify
+    # Upgrade npm to the latest version
     npm install -g npm
-
-    # Found I still hit an issue when trying to run `npm install` for the app
-    # for the first time following build. It would only succeed if I had run
-    # this before hand (one time operation. )
-    rm -rf /home/vagrant/.npm
   SHELL
 end

--- a/shipitfile.js
+++ b/shipitfile.js
@@ -59,6 +59,16 @@ module.exports = function (shipit) {
 
   // Tasks
 
+  // Verify the contents of the cache folder, garbage collecting any unneeded
+  // data, and verifying the integrity of the cache index and all cached data.
+  // Added to help try and prevent errors like this
+  // WARN registry Unexpected warning for https://registry.npmjs.org/: Miscellaneous Warning EINTEGRITY: sha512-Pbeh0i6OLubPJdIdCepn8ZQHwN2MWznZHbHABSTEfQ706ie+yuxNSaPdqX1xRatT6WanaS1EazMiSg0NUW2XxQ== integrity checksum failed when using sha512: wanted sha512-Pbeh0i6OLubPJdIdCepn8ZQHwN2MWznZHbHABSTEfQ706ie+yuxNSaPdqX1xRatT6WanaS1EazMiSg0NUW2XxQ== but got sha1-Nq/u4Nk0XwRjh85t6KZwKv5btW4=. (2915 bytes)
+  // WARN registry Using stale package data from https://registry.npmjs.org/ due to a request error during revalidation.
+  shipit.task('npm-verify', () => {
+    shipit.remote('npm cache verify')
+    shipit.emit('npm-verified')
+  })
+
   // The only way pm2 can support capistrano like deployments is if a config
   // file is used rather than calling the app directly.
   // http://pm2.keymetrics.io/docs/tutorials/capistrano-like-deployments
@@ -103,6 +113,16 @@ module.exports = function (shipit) {
   })
 
   // Event listeners
+
+  // Event emitted by shipit at the very start when it kicks off the deployment
+  shipit.on('deploy', () => {
+    shipit.start('npm-verify')
+  })
+
+  // Event emitted by shipit once it has finished all its tasks
+  shipit.on('deployed', () => {
+    shipit.start('deploy-pm2-config')
+  })
 
   // Emitted once the pm2 config file has been copied to the instance. Once it
   // has its safe to call `reload()`


### PR DESCRIPTION
When working with Vagrant and npm I tend experience the error `Unhandled rejection Error: EPERM: operation not permitted` errors frequently.

The changes made here are attempts to prevent this error from happening when running the deployment.